### PR TITLE
Use LocalVarId in more places and add GlobalVarId newtype

### DIFF
--- a/src/Prana/Decode.hs
+++ b/src/Prana/Decode.hs
@@ -59,7 +59,7 @@ decodeExpr =
       3 -> LamE <$> decodeLocalVarId <*> decodeExpr
       4 -> LetE <$> decodeArray decodeLocalBind <*> decodeExpr
       5 ->
-        CaseE <$> decodeExpr <*> decodeId <*> decodeType <*>
+        CaseE <$> decodeExpr <*> decodeLocalVarId <*> decodeType <*>
         decodeArray decodeAlt
       10 -> ConE <$> decodeConId
       11 -> PrimOpE <$> decodePrimId
@@ -114,7 +114,7 @@ decodeBool =
 decodeAlt :: Get Alt
 decodeAlt =
   label' "decodeAlt" $
-  Alt <$> decodeAltCon <*> decodeArray decodeId <*> decodeExpr
+  Alt <$> decodeAltCon <*> decodeArray decodeLocalVarId <*> decodeExpr
 
 decodeType :: Get Typ
 decodeType =
@@ -146,11 +146,14 @@ decodeId :: Get VarId
 decodeId = label' "decodeVarId" $
   do tag <- getWord8
      case tag of
-       0 -> LocalIndex <$> getInt64le
-       _ -> ExportedIndex <$> getInt64le
+       0 -> LocalIndex <$> decodeLocalVarId
+       _ -> ExportedIndex <$> decodeGlobalVarId
 
 decodeLocalVarId :: Get LocalVarId
 decodeLocalVarId = LocalVarId <$> getInt64le
+
+decodeGlobalVarId :: Get GlobalVarId
+decodeGlobalVarId  = GlobalVarId <$> getInt64le
 
 decodeUnique :: Get Unique
 decodeUnique = label' "decodeUnique" $ fmap Unique getInt64le

--- a/src/Prana/Interpret.hs
+++ b/src/Prana/Interpret.hs
@@ -44,11 +44,11 @@ eval methods global local =
         body
     VarE var ->
       case var of
-        ExportedIndex i ->
+        ExportedIndex (GlobalVarId i) ->
           case HM.lookup i global of
             Nothing -> error "eval.VarE.ExportedIndex = Nothing"
             Just e -> eval methods global local e
-        LocalIndex i ->
+        LocalIndex (LocalVarId i) ->
           case HM.lookup i local of
             Nothing -> error "eval.VarE.LocalIndex = Nothing"
             Just e -> eval methods global local e

--- a/src/Prana/Types.hs
+++ b/src/Prana/Types.hs
@@ -27,7 +27,7 @@ data Exp
   --
   = AppE Exp Exp -- ^ Apply a function to an argument.
   | LamE LocalVarId Exp -- ^ A lambda.
-  | CaseE Exp VarId Typ [Alt] -- ^ A case analysis.
+  | CaseE Exp LocalVarId Typ [Alt] -- ^ A case analysis.
   | LetE [(LocalVarId, Exp)] Exp -- ^ Let binding of variables.
   --
   -- Constants
@@ -62,7 +62,10 @@ data WiredId = WiredId
 data FFIId = FFIId
   deriving (Generic, Data, Typeable, Eq, Show, Ord)
 
-data VarId = LocalIndex !Int64 | ExportedIndex !Int64
+data VarId = LocalIndex !LocalVarId | ExportedIndex !GlobalVarId
+  deriving (Generic, Data, Typeable, Eq, Show, Ord)
+
+newtype GlobalVarId = GlobalVarId Int64
   deriving (Generic, Data, Typeable, Eq, Show, Ord)
 
 newtype LocalVarId = LocalVarId Int64
@@ -76,7 +79,7 @@ data Typ = TyConApp TyId [Typ] | OpaqueType ByteString
 
 data Alt = Alt
   { altCon :: AltCon
-  , altVars :: [VarId]
+  , altVars :: [LocalVarId]
   , altExp :: Exp
   } deriving (Generic, Data, Typeable, Eq, Show, Ord)
 

--- a/test/TestLib.hs
+++ b/test/TestLib.hs
@@ -1,6 +1,8 @@
-{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults -fno-warn-orphans #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- |
 
@@ -19,6 +21,9 @@ import           Prana.Types
 import           System.Exit
 import           System.IO.Temp
 import           System.Process
+
+deriving instance Num LocalVarId
+deriving instance Num GlobalVarId
 
 data CompileType = Normal
 
@@ -122,7 +127,7 @@ link mods = (globals, locals)
         (mapMaybe
            (\b ->
               case bindVar b of
-                ExportedIndex i -> Just (i, bindExp b)
+                ExportedIndex (GlobalVarId i) -> Just (i, bindExp b)
                 _ -> Nothing)
            bs)
     locals =
@@ -130,7 +135,7 @@ link mods = (globals, locals)
         (mapMaybe
            (\b ->
               case bindVar b of
-                LocalIndex i -> Just (i, bindExp b)
+                LocalIndex (LocalVarId i) -> Just (i, bindExp b)
                 _ -> Nothing)
            bs)
 


### PR DESCRIPTION
This changes the prana file serialization because some spots now use
`LocalVarId` instead of `VarId`.